### PR TITLE
Fix infinite unknown character error in c compiler

### DIFF
--- a/simple_c_compiler.c
+++ b/simple_c_compiler.c
@@ -369,6 +369,12 @@ loop:
     default:
 unkn:
         error("Unknown character");
+        // Consume the next character to avoid infinite loop
+        c = getcc();
+        if (c == '\0' || c == '\004') {
+            eof++;
+            return 0;
+        }
         goto loop;
     }
 }


### PR DESCRIPTION
Fix infinite 'Unknown character' error loop by consuming the problematic character.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e12824f-d980-4c2f-b402-8a0403cd77a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e12824f-d980-4c2f-b402-8a0403cd77a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

